### PR TITLE
Fix iconv call on OS X

### DIFF
--- a/Core/GDCore/IDE/Dialogs/InstancesAdvancedPasteDialog.cpp
+++ b/Core/GDCore/IDE/Dialogs/InstancesAdvancedPasteDialog.cpp
@@ -127,7 +127,7 @@ InstancesAdvancedPasteDialog::InstancesAdvancedPasteDialog(wxWindow* parent,wxWi
 	FlexGridSizer4 = new wxFlexGridSizer(0, 3, 0, 0);
 	rotationEdit = new wxTextCtrl(this, ID_TEXTCTRL1, _("0"), wxDefaultPosition, wxSize(44,21), 0, wxDefaultValidator, _T("ID_TEXTCTRL1"));
 	FlexGridSizer4->Add(rotationEdit, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
-	StaticText5 = new wxStaticText(this, ID_STATICTEXT5, _("°"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT5"));
+	StaticText5 = new wxStaticText(this, ID_STATICTEXT5, _("deg"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT5"));
 	FlexGridSizer4->Add(StaticText5, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
 	FlexGridSizer3->Add(FlexGridSizer4, 1, wxALL|wxEXPAND|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
 	StaticBoxSizer2->Add(FlexGridSizer3, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);

--- a/Core/GDCore/PlatformDefinition/Project.cpp
+++ b/Core/GDCore/PlatformDefinition/Project.cpp
@@ -798,15 +798,19 @@ bool Project::LoadFromFile(const gd::String & filename)
             outStream.close();
             docStream.close();
 
-#else //ON LINUX OR MAC OS X
+#else
             //Convert using iconv command tool
-            std::cout << "Executing " << "iconv -f LATIN1 -t UTF-8 \"" + filename.ToLocale() + "\" -o  \"" + tmpFileName + "\"" << std::endl;
-    #if !defined(GD_NO_WX_GUI)
-            wxExecute("iconv -f LATIN1 -t UTF-8 \"" + filename.ToLocale() + "\" -o  \"" + tmpFileName + "\"", wxEXEC_BLOCK);
-    #else
-            std::string command = "iconv -f LATIN1 -t UTF-8 \"" + filename.ToLocale() + "\" -o  \"" + std::string(tmpFileName) + "\"";
-            system(command.c_str());
-    #endif
+            gd::String iconvCall = gd::String("iconv -f LATIN1 -t UTF-8 \"") + filename.ToLocale() + "\" ";
+            #if defined(MACOS)
+            iconvCall += "> \"" + tmpFileName + "\"";
+            #else
+            iconvCall += "-o \"" + tmpFileName + "\"";
+            #endif
+
+            std::cout << "Executing " << iconvCall  << std::endl;
+            #if !defined(GD_NO_WX_GUI)
+            system(iconvCall.c_str());
+            #endif
 #endif
 
             //Reload the converted file, forcing UTF8 encoding as the XML header is false (still written ISO-8859-1)


### PR DESCRIPTION
Also exclude the whole UTF8 conversion process when compiling without wxWidgets.
